### PR TITLE
Fix for PROPFIND and Auth #16/#20

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -33,6 +33,7 @@ http {
     set $destination $http_destination; 
     set $new_path "";
     set $webdav_root "/data";
+    set $checkPropfind "";
     
     location ~ \.(_.*|DS_Store|Spotlight-V100|TemporaryItems|Trashes|hidden|localized)$ {
       access_log  off;
@@ -73,6 +74,7 @@ http {
       error_page		599 = @propfind_handler;
       error_page		598 = @delete_handler;
       error_page		597 = @copy_move_handler;
+      error_page		596 = @propfind_withdepth_handler;
       
       open_file_cache		off;
       
@@ -103,9 +105,25 @@ http {
       }
       
       
-      if ($request_method = PROPFIND) {
-        return 599;
+      if ($request_method = PROPFIND) { # Normal flow for PROPFIND
+        set $checkPropfind "propfind";
       }
+      
+      if ($http_depth = 0) { # FIX for Depth = 0 allowed unauthenticated
+        set $checkPropfind "${checkPropfind}+withDepth";
+      }
+      
+      if ($http_depth = 1) { # FIX for Depth = 1 allowed unauthenticated
+        set $checkPropfind "${checkPropfind}+withDepth";
+      }
+      
+      if ($checkPropfind = "propfind") { # Normal flow for PROPFIND
+        return 599;
+      } 
+      
+      if ($checkPropfind = "propfind+withDepth") { # FIX for Depth = 1 allowed unauthenticated
+        return 596;
+      }   
       
       if ($request_method = PROPPATCH) { # Unsupported, allways return OK.
         add_header	Content-Type 'text/xml';
@@ -136,6 +154,25 @@ http {
       internal;
 
       open_file_cache	off;
+      
+      
+      if (!-e $webdav_root/$uri) { # Microsoft specific handle.
+        return 404;
+      }
+      
+      root			$webdav_root;
+      dav_ext_methods		PROPFIND;
+    }
+    
+    location @propfind_withdepth_handler { # Same as above but authenticated.
+    
+      auth_basic "Restricted";
+      auth_basic_user_file htpasswd;
+    
+      internal;
+
+      open_file_cache	off;
+      
       
       if (!-e $webdav_root/$uri) { # Microsoft specific handle.
         return 404;


### PR DESCRIPTION
PROPFIND requests with Depth = 1 and no auth header will reveal the filesystem structure. This hack adds authentication for such cases only. Otherwise, PROPFIND does not require authentication.