### PR TITLE
Automated docker building & publishing to Docker Hub & GitHub packages using GitHub Actions/Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,8 +9,7 @@ on:
     branches: [ main ]
 
 env:
-  IMAGE_NAME: ${{ github.actor }}/nginx-webdav-nononsense
-
+  IMAGE_NAME: ${{ github.repository_owner }}/nginx-webdav-nononsense
 
 jobs:
   build:
@@ -55,7 +54,7 @@ jobs:
         uses: docker/login-action@v1.14.1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v2.1.0
+        uses: sigstore/cosign-installer@v2.2.1
         with:
           cosign-release: 'v1.6.0'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,102 @@
+name: build & publish docker image
+
+on:
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ '*.*.*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  IMAGE_NAME: ${{ github.actor }}/nginx-webdav-nononsense
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v2.1.0
+        with:
+          cosign-release: 'v1.6.0'
+
+      - name: Setup QEMU binaries
+        uses: docker/setup-qemu-action@v1.2.0
+        
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1.6.0
+        with:
+          buildkitd-flags: --debug
+
+      - name: Log into Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1.14.1
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Log into GitHub registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=pep440,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v2.9.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: cosign sign ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,7 +61,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3.6.2
+        uses: docker/metadata-action@v3.7.0
         with:
           images: |
             ${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/build-push-action@v2.9.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,8 +67,6 @@ jobs:
             ${{ env.IMAGE_NAME }}
             ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha
-            type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v2.9.0
+        uses: docker/build-push-action@v2.10.0
         with:
           context: .
           platforms: linux/amd64,linux/arm/v7,linux/arm64

--- a/.github/workflows/update-dockerhub-description.yml
+++ b/.github/workflows/update-dockerhub-description.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: update docker hub repository description
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}

--- a/.github/workflows/update-dockerhub-description.yml
+++ b/.github/workflows/update-dockerhub-description.yml
@@ -1,0 +1,26 @@
+name: Update Docker Hub description
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'README.md'
+      - '.github/workflows/update-dockerhub-description.yml'
+
+env:
+  IMAGE_NAME: nginx-webdav-nononsense
+  
+jobs:
+  update:
+    name: Update Docker Hub description
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: update docker hub repository description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+          repository: ${{ secrets.DOCKER_REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/update-dockerhub-description.yml
+++ b/.github/workflows/update-dockerhub-description.yml
@@ -24,3 +24,4 @@ jobs:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
           repository: ${{ secrets.DOCKER_REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          short-description: ${{ github.event.repository.description }}


### PR DESCRIPTION
Reason for this PR is simple, building the container image on my raspberry pi 4 takes to much f'ing time and GitHub's Action resources are free, so...

This pull requests adds several things:

### 1. Workflow [docker-publish](https://github.com/dotWee/docker-nginx-webdav-nononsense/blob/main/.github/workflows/docker-publish.yml)

#### Important notes:

This workflow will run on new git tags or new commits to the _main_ branch.
When triggered, it will build docker images for platforms `amd64`, `arm64` & `armv7` using the repository source.
> **Note**: `amd64` & `arm64` builds are tested, `armv7` currently not! Also, I tried building for `armv6`, but this [failed](https://github.com/dotWee/docker-nginx-webdav-nononsense/pull/3) as the builder image `lscr.io/linuxserver/baseimage-ubuntu:focal` has no `armv6` image.

Each built image will be tagged as `latest` on new commits to the main branch (instead of only on new git tags).
When built successfully, images will be pushed to GitHub Packages & Docker Hub registry.
I've set the image name to `${{ github.repository_owner }}/nginx-webdav-nononsense` to get rid of the `docker-` prefix.

#### Required setup actions:

- Make sure to have variables `DOCKER_REGISTRY_PASSWORD` and `DOCKER_REGISTRY_USERNAME` defined within the repository action secrets (required for pushing to Docker Hub)

### 2. Workflow [update-dockerhub-description](https://github.com/dotWee/docker-nginx-webdav-nononsense/blob/main/.github/workflows/update-dockerhub-description.yml)

This workflow will run when the `README.md` file or the workflow file on main branch gets changed.
It simply uses the README.md file as Docker Hub description base.

> **Note:** It also requires `DOCKER_REGISTRY_PASSWORD` and `DOCKER_REGISTRY_USERNAME` to be defined.

### 3. [Dependabot](https://github.com/dotWee/docker-nginx-webdav-nononsense/blob/main/.github/dependabot.yml)

This is the configuration file for using GitHub's Dependabot with it's natively supported GitHub Action integration.
It will automatically keep the workflow actions up to date.

Example pull request that appeared while writing the workflows: https://github.com/dotWee/docker-nginx-webdav-nononsense/pull/2