### PR TITLE
Always use named captures to work around nginx bug #348

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -134,7 +134,7 @@ http {
       }
       
       if ($request_method = MKCOL) { # Microsoft specific handle: add trailing slash.
-        rewrite ^(.*[^/])$ $1/ break;
+        rewrite ^(?<captured_path>.*[^/])$ $captured_path/ break;
       }
       
       if ($request_method = DELETE) {
@@ -194,14 +194,14 @@ http {
       internal;
       open_file_cache	off;
       
-      if ($destination ~ ^https?://(.*)$) {
-        set $new_path $1;
+      if ($destination ~ ^https?://(?<captured_path>.*)$) {
+        set $new_path $captured_path;
         more_set_input_headers "Destination: http://$new_path";
       }
       
       if (-d $webdav_root/$uri) { # Microsoft specific handle: Add trailing slash to dirs.
         more_set_input_headers "Destination: http://$new_path/";
-        rewrite ^(.*[^/])$ $1/ break;
+        rewrite ^(?<captured_path>.*[^/])$ $captured_path/ break;
       }
       
       root			$webdav_root;
@@ -216,14 +216,14 @@ http {
       internal;
       open_file_cache	off;
       
-      if ($destination ~ ^https?://(.*)$) {
-        set $new_path $1;
+      if ($destination ~ ^https?://(?<captured_path>.*)$) {
+        set $new_path $captured_path;
         more_set_input_headers "Destination: http://$new_path";
       }
       
       if (-d $webdav_root/$uri) { # Microsoft specific handle: Add trailing slash to dirs.
         more_set_input_headers "Destination: http://$new_path/";
-        rewrite ^(.*[^/])$ $1/ break;
+        rewrite ^(?<captured_path>.*[^/])$ $captured_path/ break;
       }
       
       root			$webdav_root;


### PR DESCRIPTION
When moving (or copying) a file, there is a bug that occurs when the old and new names of the file both contain a space character. Specifically, this scenario triggers a known [nginx bug #348](https://trac.nginx.org/nginx/ticket/348), where the contents of the `Destination` header are incorrectly re-urlencoded when they are extracted by a regular expression. As a result, the file's new name is mangled:

```
/Volumes/webdav.mydomain.com ᐅ touch "foo bar.txt"
/Volumes/webdav.mydomain.com ᐅ ls
foo bar.txt
/Volumes/webdav.mydomain.com ᐅ mv "foo bar.txt" "baz boof.txt"
/Volumes/webdav.mydomain.com ᐅ ls
baz%20boof.txt
```

This PR fixes the problem using the workaround described in the nginx bug comment thread: named captures.

Behavior with the fix in place:

```
/Volumes/webdav.mydomain.com ᐅ touch "foo bar.txt"
/Volumes/webdav.mydomain.com ᐅ ls
foo bar.txt
/Volumes/webdav.mydomain.com ᐅ mv "foo bar.txt" "baz boof.txt"
/Volumes/webdav.mydomain.com ᐅ ls
baz boof.txt
```