### PR TITLE
Change nginx-dav-ext-module version from arut's to mid1221213's inside Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Daniel Graziotin, daniel@ineed.coffee"
 
 ARG NGINX_VER_ARG=1.25.3
 ENV NGINX_VER=$NGINX_VER_ARG 
-ENV NGINX_DAV_EXT_VER 3.0.0
+ENV NGINX_DAV_EXT_VER 4.0.1
 ENV NGINX_FANCYINDEX_VER 0.5.2
 ENV HEADERS_MORE_VER 0.34
 
@@ -39,7 +39,7 @@ RUN apt-get update && \
 
 WORKDIR /usr/src
 RUN wget https://nginx.org/download/nginx-${NGINX_VER}.tar.gz -O /usr/src/nginx-${NGINX_VER}.tar.gz && \
-  wget https://github.com/arut/nginx-dav-ext-module/archive/v${NGINX_DAV_EXT_VER}.tar.gz \
+  wget https://github.com/mid1221213/nginx-dav-ext-module/archive/v${NGINX_DAV_EXT_VER}.tar.gz \
     -O /usr/src/nginx-dav-ext-module-v${NGINX_DAV_EXT_VER}.tar.gz && \
   wget https://github.com/aperezdc/ngx-fancyindex/archive/v${NGINX_FANCYINDEX_VER}.tar.gz \
     -O /usr/src/ngx-fancyindex-v${NGINX_FANCYINDEX_VER}.tar.gz && \


### PR DESCRIPTION
This comes with some advantages, such as:

[Fix PROPFIND fail with 500 on symlinks to non existing file/dir.](https://github.com/arut/nginx-dav-ext-module/commit/6363d97cb6905df57f623a039300455ed65cdc53)
[Fix for properly dealing with Unix hidden folders](https://github.com/arut/nginx-dav-ext-module/commit/51185d0aa980bafcd02f5a039cf6e46e75b35935)
[Fix to fail with a 412 in case of bad UNLOCK token](https://github.com/arut/nginx-dav-ext-module/commit/74a23a64311a9178eba279707ed79f51390d1010)
[Fix DAV class from 2 to 1,2 (like apache)](https://github.com/arut/nginx-dav-ext-module/commit/9f112cf8e396ea5e1bdc70cedfa4f5cbc48fe98a)

My use case is primarily for dealing with Unix hidden folders as I wasn't able to synchronize them before I made this change in my own Dockerfile