### PR TITLE
fix: Don't fail if password contains spaces

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -12,7 +12,7 @@ fi
 if [ ! -e "/etc/nginx/htpasswd" ]; then
   touch "/etc/nginx/htpasswd"
   if [ "x$WEBDAV_USERNAME" != "x" ] && [ "x$WEBDAV_PASSWORD" != "x" ]; then
-    htpasswd -bc /etc/nginx/htpasswd $WEBDAV_USERNAME $WEBDAV_PASSWORD
+    htpasswd -bc /etc/nginx/htpasswd "$WEBDAV_USERNAME" "$WEBDAV_PASSWORD"
     # root /data/$remote_user;
   else
     # no auth


### PR DESCRIPTION
`htpasswd` command fails if the password has spaces in it. I've enclosed it in quotes to fix it.