### PR TITLE
Fix "unable to start service init-paths" upon restarts

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-paths/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-paths/run
@@ -47,5 +47,5 @@ fi
 
 if [ -e /config/nginx/htpasswd ]; then
     echo "Linking /config/nginx/htpasswd to /etc/nginx/htpasswd"
-    ln -s /config/nginx/htpasswd /etc/nginx
+    ln -sf /config/nginx/htpasswd /etc/nginx
 fi


### PR DESCRIPTION
Without this patch, the service will not start properly except the first time.

Error messages:

```
Linking /config/nginx/htpasswd to /etc/nginx/htpasswd
ln: failed to create symbolic link '/etc/nginx/htpasswd': File exists
s6-rc: warning: unable to start service init-paths: command exited 1
```

And then nginx won't start either (failed service dependency in init?). Users then get a confusing 502 error through the reverse proxy.

This PR assumes that you intended to unconditionally overwrite it. Let me know if you'd like to test for the symbolic link instead like the lines above. That'd fix it too.